### PR TITLE
Terraform

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/target-cli.iml" filepath="$PROJECT_DIR$/.idea/target-cli.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/target-cli.iml
+++ b/.idea/target-cli.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/cmd/boundaryupdate.go
+++ b/cmd/boundaryupdate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -50,7 +51,12 @@ var boundaryUpdateCmd = &cobra.Command{
 		c.Boundary[args[0]] = b
 
 		viper.Set("boundary", c.Boundary)
-		viper.WriteConfig()
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+
+		fmt.Printf("Updated Boundary profile %s\n", args[0])
 	},
 }
 

--- a/cmd/boundaryupdate.go
+++ b/cmd/boundaryupdate.go
@@ -56,7 +56,7 @@ var boundaryUpdateCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Updated Boundary profile %s\n", args[0])
+		fmt.Printf("Updated Boundary profile '%s'\n", args[0])
 	},
 }
 

--- a/cmd/consulcreate.go
+++ b/cmd/consulcreate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,7 +39,11 @@ var consulCreateCmd = &cobra.Command{
 		c.Consul[args[0]] = C
 
 		viper.Set("consul", c.Consul)
-		viper.WriteConfig()
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+		fmt.Printf("Created Consul profile '%s'\n", args[0])
 
 	},
 }

--- a/cmd/consulupdate.go
+++ b/cmd/consulupdate.go
@@ -47,7 +47,7 @@ var consulUpdateCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Updated Consul profile %s\n", args[0])
+		fmt.Printf("Updated Consul profile '%s'\n", args[0])
 	},
 }
 

--- a/cmd/consulupdate.go
+++ b/cmd/consulupdate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,7 +42,12 @@ var consulUpdateCmd = &cobra.Command{
 		c.Consul[args[0]] = C
 
 		viper.Set("consul", c.Consul)
-		viper.WriteConfig()
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+
+		fmt.Printf("Updated Consul profile %s\n", args[0])
 	},
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -107,3 +107,32 @@ var deleteBoundaryCmd = &cobra.Command{
 		}
 	},
 }
+
+var deleteTerraformCmd = &cobra.Command{
+	Use:     "delete",
+	Short:   "delete removes a context profile",
+	Long:    `delete a context with the delete command.`,
+	Example: `target terraform delete -n example`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("requires a name argument")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		nameToDelete := args[0]
+
+		// Check if the Vault profile with the given name exists and delete it
+		if _, exists := c.Terraform[args[0]]; exists {
+			delete(c.Terraform, args[0])
+			viper.Set("terraform", c.Terraform)
+			err := viper.WriteConfig()
+			if err != nil {
+				return
+			}
+			fmt.Printf("Deleted Terraform profile '%s'\n", nameToDelete)
+		} else {
+			fmt.Printf("Terraform profile '%s' not found\n", nameToDelete)
+		}
+	},
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -61,3 +61,17 @@ var listBoundaryCmd = &cobra.Command{
 		}
 	},
 }
+
+var listTerraformCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "list all context profiles for your chosen tool",
+	Long:    `list all context profiles for Vault using the list command`,
+	Example: `target terraform list`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		fmt.Println("########################################\n##              Terraform             ##\n########################################")
+		for i := range c.Terraform {
+			fmt.Printf("%s\n", i)
+		}
+	},
+}

--- a/cmd/nomadupdate.go
+++ b/cmd/nomadupdate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -38,7 +39,12 @@ var nomadUpdateCmd = &cobra.Command{
 		c.Nomad[args[0]] = n
 
 		viper.Set("nomad", c.Nomad)
-		viper.WriteConfig()
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+
+		fmt.Printf("Updated Nomad profile %s\n", args[0])
 	},
 }
 

--- a/cmd/nomadupdate.go
+++ b/cmd/nomadupdate.go
@@ -44,7 +44,7 @@ var nomadUpdateCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Updated Nomad profile %s\n", args[0])
+		fmt.Printf("Updated Nomad profile '%s'\n", args[0])
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,11 +19,16 @@ var version string
 
 // Config struct containing different product profiles
 type Config struct {
-	Vault    map[string]*Vault    `json:"vault,omitempty" mapstructure:"vault"`
-	Consul   map[string]*Consul   `json:"consul,omitempty" mapstructure:"consul"`
-	Nomad    map[string]*Nomad    `json:"nomad,omitempty" mapstructure:"nomad"`
-	Boundary map[string]*Boundary `json:"boundary,omitempty" mapstructure:"boundary"`
+	Vault     map[string]*Vault     `json:"vault,omitempty" mapstructure:"vault"`
+	Consul    map[string]*Consul    `json:"consul,omitempty" mapstructure:"consul"`
+	Nomad     map[string]*Nomad     `json:"nomad,omitempty" mapstructure:"nomad"`
+	Boundary  map[string]*Boundary  `json:"boundary,omitempty" mapstructure:"boundary"`
+	Terraform map[string]*Terraform `json:"terraform,omitempty" mapstructure:"terraform"`
 	//Default  map[string]*Default  `json:"default,omitempty" mapstructure:"default"`
+}
+
+type Terraform struct {
+	Vars map[string]string `json:"vars,omitempty" mapstructure:"vars"`
 }
 
 type Boundary struct {
@@ -127,6 +132,7 @@ Example:
 		"nomad",
 		"consul",
 		"boundary",
+		"terraform",
 		"config",
 	},
 	Args:    cobra.OnlyValidArgs,
@@ -152,6 +158,7 @@ func init() {
 	rootCmd.AddCommand(consulCmd)
 	rootCmd.AddCommand(configlCmd)
 	rootCmd.AddCommand(boundaryCmd)
+	rootCmd.AddCommand(terraformCmd)
 
 }
 
@@ -227,6 +234,9 @@ func initConfig() {
 		}
 		if c.Boundary == nil {
 			c.Boundary = map[string]*Boundary{}
+		}
+		if c.Terraform == nil {
+			c.Terraform = map[string]*Terraform{}
 		}
 	}
 

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -535,3 +535,35 @@ var selectBoundaryCmd = &cobra.Command{
 		fmt.Println(commandStr)
 	},
 }
+
+var selectTerraformCmd = &cobra.Command{
+	Use:     "select [name]",
+	Short:   "select a context profile",
+	Long:    `select a context profile to use with the select command.`,
+	Example: `target terraform select example"`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("requires a name argument")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		profile := args[0]
+
+		if c.Terraform[args[0]] == nil {
+			log.Fatalf("Profile %s not found", profile)
+		}
+
+		context := c.Terraform[args[0]]
+
+		var exportCommandStr []string
+
+		for k, v := range context.Vars {
+			command := fmt.Sprintf("export TF_VAR_%s=%s", k, v)
+			exportCommandStr = append(exportCommandStr, command)
+		}
+
+		commandStr := strings.Join(exportCommandStr, "; ")
+		fmt.Println(commandStr)
+	},
+}

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -24,4 +24,5 @@ func init() {
 	terraformCmd.AddCommand(deleteTerraformCmd)
 	terraformCmd.AddCommand(listTerraformCmd)
 	terraformCmd.AddCommand(terraformUpdateCmd)
+	terraformCmd.AddCommand(selectTerraformCmd)
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,8 +1,16 @@
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"github.com/devops-rob/target-cli/pkg/targetdir"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+	"strings"
+)
 
-var tfVars map[string]string
+//var tfVars map[string]string
 
 var terraformCmd = &cobra.Command{
 	Use:   "terraform",
@@ -19,10 +27,65 @@ var terraformCmd = &cobra.Command{
 	DisableFlagsInUseLine: true,
 }
 
+var terraformSetDefaultCmd = &cobra.Command{
+	Use:                   "set-default",
+	Short:                 "set a default context profile for Terraform ",
+	Long:                  `set a default context profile for Terraform.`,
+	DisableFlagsInUseLine: true,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("requires a name argument")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if c.Terraform[args[0]] == nil {
+			log.Fatalf("Profile %s not found", args[0])
+		}
+
+		context := c.Terraform[args[0]]
+
+		var exportCommandStr []string
+
+		for k, v := range context.Vars {
+			command := fmt.Sprintf("export TF_VAR_%s=%s", k, v)
+			exportCommandStr = append(exportCommandStr, command)
+
+		}
+
+		commandStr := strings.Join(exportCommandStr, "; ")
+
+		defaultScript := `
+#!/bin/bash
+` + commandStr
+
+		absolutePath := targetdir.TargetHome() + "/defaults/terraform.sh"
+
+		file, err := os.OpenFile(absolutePath, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer func(file *os.File) {
+			err := file.Close()
+			if err != nil {
+				log.Fatal(err)
+			}
+		}(file)
+		_, err = file.WriteString(defaultScript)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println("default profile set")
+	},
+}
+
 func init() {
 	terraformCmd.AddCommand(terraformCreateCmd)
 	terraformCmd.AddCommand(deleteTerraformCmd)
 	terraformCmd.AddCommand(listTerraformCmd)
 	terraformCmd.AddCommand(terraformUpdateCmd)
 	terraformCmd.AddCommand(selectTerraformCmd)
+	terraformCmd.AddCommand(terraformSetDefaultCmd)
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -22,4 +22,5 @@ var terraformCmd = &cobra.Command{
 func init() {
 	terraformCmd.AddCommand(terraformCreateCmd)
 	terraformCmd.AddCommand(deleteTerraformCmd)
+	terraformCmd.AddCommand(listTerraformCmd)
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var tfVars map[string]string
+
+var terraformCmd = &cobra.Command{
+	Use:   "terraform",
+	Short: "Manage Terraform context profiles ",
+	Long:  `Manage Terraform context profiles.`,
+	ValidArgs: []string{
+		"create",
+		"delete",
+		"list",
+		"select",
+		"update",
+		"set-default",
+	},
+	DisableFlagsInUseLine: true,
+}
+
+func init() {
+	terraformCmd.AddCommand(terraformCreateCmd)
+}

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -23,4 +23,5 @@ func init() {
 	terraformCmd.AddCommand(terraformCreateCmd)
 	terraformCmd.AddCommand(deleteTerraformCmd)
 	terraformCmd.AddCommand(listTerraformCmd)
+	terraformCmd.AddCommand(terraformUpdateCmd)
 }

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -21,4 +21,5 @@ var terraformCmd = &cobra.Command{
 
 func init() {
 	terraformCmd.AddCommand(terraformCreateCmd)
+	terraformCmd.AddCommand(deleteTerraformCmd)
 }

--- a/cmd/terraformcreate.go
+++ b/cmd/terraformcreate.go
@@ -55,7 +55,6 @@ var terraformCreateCmd = &cobra.Command{
 
 func init() {
 
-	//terraformCreateCmd.Flags().StringSlice("var", map[string]string, "set a terraform variable in a key/value pair, e.g name=rob. Can be specified multiple times")
 	terraformCreateCmd.PersistentFlags().StringSliceVarP(&tfVarFlag, "var", "v", []string{}, "set a terraform variable in a key/value pair, e.g name=rob. Can be specified multiple times")
 
 	err := terraformCreateCmd.MarkPersistentFlagRequired(

--- a/cmd/terraformcreate.go
+++ b/cmd/terraformcreate.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"log"
+	"strings"
+)
+
+var tfVarFlag []string
+
+var terraformCreateCmd = &cobra.Command{
+	Use:     "create [name]",
+	Short:   "create command creates a context profile",
+	Long:    `create a context profile with the create command.`,
+	Example: `target terraform create example --var "project_id=1234567" --var "vault_addr=https://prd-vault.target:8200"`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("requires a name argument")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if c.Terraform[args[0]] != nil {
+			log.Fatal("profile already exists")
+
+		}
+
+		result := make(map[string]string)
+		for _, item := range tfVarFlag {
+			parts := strings.SplitN(item, "=", 2)
+			if len(parts) == 2 {
+				result[parts[0]] = parts[1]
+			}
+		}
+
+		t := &Terraform{
+			Vars: result,
+		}
+
+		c.Terraform[args[0]] = t
+
+		viper.Set("terraform", c.Terraform)
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+		fmt.Printf("Created Terraform profile '%s'\n", args[0])
+
+	},
+}
+
+func init() {
+
+	//terraformCreateCmd.Flags().StringSlice("var", map[string]string, "set a terraform variable in a key/value pair, e.g name=rob. Can be specified multiple times")
+	terraformCreateCmd.PersistentFlags().StringSliceVarP(&tfVarFlag, "var", "v", []string{}, "set a terraform variable in a key/value pair, e.g name=rob. Can be specified multiple times")
+
+	err := terraformCreateCmd.MarkPersistentFlagRequired(
+		"var",
+	)
+	if err != nil {
+		return
+	}
+
+}

--- a/cmd/terraformupdate.go
+++ b/cmd/terraformupdate.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/terraformupdate.go
+++ b/cmd/terraformupdate.go
@@ -47,7 +47,7 @@ var terraformUpdateCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Updated Terraform profile %s\n", args[0])
+		fmt.Printf("Updated Terraform profile '%s'\n", args[0])
 
 	},
 }

--- a/cmd/terraformupdate.go
+++ b/cmd/terraformupdate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -45,6 +46,8 @@ var terraformUpdateCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
+
+		fmt.Printf("Updated Terraform profile %s\n", args[0])
 
 	},
 }

--- a/cmd/terraformupdate.go
+++ b/cmd/terraformupdate.go
@@ -1,1 +1,62 @@
 package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"log"
+	"strings"
+)
+
+var terraformUpdateCmd = &cobra.Command{
+	Use:     "update [name]",
+	Short:   "Update an existing context",
+	Long:    `The update command allows you to modify an existing context.`,
+	Example: `target terraform update example --var rob=theauthor`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("requires a name argument")
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if c.Terraform[args[0]] == nil {
+			log.Fatal("profile does not exists.  Try using the create command")
+
+		}
+
+		result := make(map[string]string)
+		for _, item := range tfVarFlag {
+			parts := strings.SplitN(item, "=", 2)
+			if len(parts) == 2 {
+				result[parts[0]] = parts[1]
+			}
+		}
+
+		t := &Terraform{
+			Vars: result,
+		}
+
+		c.Terraform[args[0]] = t
+
+		c.Terraform[args[0]] = t
+		viper.Set("terraform", c.Terraform)
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+
+	},
+}
+
+func init() {
+	terraformUpdateCmd.PersistentFlags().StringSliceVarP(&tfVarFlag, "var", "v", []string{}, "set a terraform variable in a key/value pair, e.g name=rob. Can be specified multiple times")
+
+	err := terraformCreateCmd.MarkPersistentFlagRequired(
+		"var",
+	)
+	if err != nil {
+		return
+	}
+
+}

--- a/cmd/vaultupdate.go
+++ b/cmd/vaultupdate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -54,7 +55,12 @@ var vaultUpdateCmd = &cobra.Command{
 
 		c.Vault[args[0]] = v
 		viper.Set("vault", c.Vault)
-		viper.WriteConfig()
+		err := viper.WriteConfig()
+		if err != nil {
+			return
+		}
+
+		fmt.Printf("Updated Vault profile %s\n", args[0])
 
 	},
 }

--- a/cmd/vaultupdate.go
+++ b/cmd/vaultupdate.go
@@ -60,7 +60,7 @@ var vaultUpdateCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Printf("Updated Vault profile %s\n", args[0])
+		fmt.Printf("Updated Vault profile '%s'\n", args[0])
 
 	},
 }

--- a/pkg/targetdir/targetdir.go
+++ b/pkg/targetdir/targetdir.go
@@ -26,7 +26,7 @@ func TargetHome() string {
 // TargetHomeCreate checks for the target directory
 // and profiles.json file and creates if they don't exist
 func TargetHomeCreate() {
-	var defaultConfig = "{\n\t\"vault\": {},\n\t\"consul\": {},\n\t\"nomad\": {}\n}"
+	var defaultConfig = "{\n\t\"vault\": {},\n\t\"consul\": {},\n\t\"nomad\": {}\n\t\"terraform\": {}\n}"
 	targetHome := TargetHome()
 	if _, err := os.Stat(targetHome); os.IsNotExist(err) {
 		os.Mkdir(targetHome, 0755)


### PR DESCRIPTION
This PR adds the functionality to set terraform variables as environment variables in a context profile. One context profile may have variable definitions for a particular environment, and another profile could have different values for its respective environment. It renders the results as `export TF_VAR_variable_name=variable_value`